### PR TITLE
fix: support to change config

### DIFF
--- a/config/samples/opengemini-operator_v1_geminicluster.yaml
+++ b/config/samples/opengemini-operator_v1_geminicluster.yaml
@@ -7,6 +7,7 @@ spec:
   affinity:
     enablePodAntiAffinity: false
   enableHttpAuth: false
+  customConfigMapName: custom-config
   monitoring:
     type: string
   paused: false

--- a/controllers/geminicluster_controller_test.go
+++ b/controllers/geminicluster_controller_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MockK8sClient struct {
+	client.Client
+}
+
+func (MockK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	obj.(*corev1.ConfigMap).Data = map[string]string{
+		"opengemini.conf": `
+[common] 
+meta-join = ["opengemini-meta-01.test.svc.cluster.local:8092", "opengemini-meta-02.test.svc.cluster.local:8092", "opengemini-meta-03.test.svc.cluster.local:8092"]
+executor-memory-size-limit= "16G"  
+executor-memory-wait-time = "0s"
+cpu-num = 8  
+memory-size = "32G"`,
+	}
+
+	return nil
+}
+
+func (MockK8sClient) Scheme() *runtime.Scheme {
+	return nil
+}
+
+func (MockK8sClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+type MockK8sController struct {
+	K8sController
+}
+
+func (MockK8sController) SetControllerReference(owner, controlled metav1.Object, scheme *runtime.Scheme) error {
+	return nil
+}
+
+func Test_ReconcileClusterConfigMap(t *testing.T) {
+	var r = &GeminiClusterReconciler{
+		Client:     &MockK8sClient{},
+		Controller: &MockK8sController{},
+	}
+
+	var metaReplicas int32 = 3
+
+	cluster := &opengeminiv1.GeminiCluster{
+		Spec: opengeminiv1.GeminiClusterSpec{
+			Meta: opengeminiv1.MetaSpec{
+				Replicas: &metaReplicas,
+			},
+			CustomConfigMapName: "config.conf",
+		},
+	}
+	cluster.Name = "test"
+	cluster.Namespace = "opengemini"
+
+	err := r.reconcileClusterConfigMap(context.Background(), cluster)
+	assert.NoError(t, err)
+	assert.Equal(t, cluster.Status.AppliedConfigHash, "1e94d9f395144eaf69571fb83161d278")
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
-	github.com/sethvargo/go-password v0.2.0
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
@@ -52,6 +53,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -63,7 +65,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,6 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
-github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -377,6 +375,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
+golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -528,8 +528,8 @@ golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/main.go
+++ b/main.go
@@ -22,11 +22,13 @@ import (
 
 	opengeminioperatorv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/controllers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -41,6 +43,12 @@ func init() {
 
 	utilruntime.Must(opengeminioperatorv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+}
+
+type k8sController struct{}
+
+func (k8sController) SetControllerReference(owner, controlled metav1.Object, scheme *runtime.Scheme) error {
+	return controllerutil.SetControllerReference(owner, controlled, scheme)
 }
 
 func main() {
@@ -88,6 +96,8 @@ func main() {
 		Client: mgr.GetClient(),
 		Owner:  controllers.ControllerManagerName,
 		Scheme: mgr.GetScheme(),
+
+		Controller: &k8sController{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GeminiCluster")
 		os.Exit(1)

--- a/pkg/configfile/configfile_test.go
+++ b/pkg/configfile/configfile_test.go
@@ -1,0 +1,99 @@
+package configfile
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UpdateConfig_ERROR(t *testing.T) {
+	tmpl := `
+[common] 
+meta-join = ["opengemini-meta-01.test.svc.cluster.local:8092
+[meta]
+  bind-address = "{{HOST_IP}}:8088"`
+	newConf := `
+[meta]
+   bind-address = "{{addr}}:8088"`
+
+	_, err := UpdateConfig(tmpl, newConf)
+	assert.Contains(t, err.Error(), "strings cannot contain newlines")
+
+	tmpl = `
+[common] 
+meta-join = ["opengemini-meta-01.test.svc.cluster.local:8092"]
+[meta]
+  bind-address = "{{HOST_IP}}:8088"`
+	newConf = `
+[meta]
+   bind-address = "{{addr}}`
+
+	_, err = UpdateConfig(tmpl, newConf)
+	assert.Contains(t, err.Error(), "unexpected EOF")
+}
+
+func Test_UpdateConfig_OK(t *testing.T) {
+	tmpl := `
+[common] 
+meta-join = ["opengemini-meta-01.test.svc.cluster.local:8092", "opengemini-meta-02.test.svc.cluster.local:8092", "opengemini-meta-03.test.svc.cluster.local:8092"]
+cpu-num = 8  
+memory-size = "32G"
+
+[meta]
+  bind-address = "{{HOST_IP}}:8088"
+  http-bind-address = "{{HOST_IP}}:8091"
+  rpc-bind-address = "{{addr}}:8092"
+  dir = "/opt/openGemini/meta"
+  domain = "{domain}"`
+	newConf := `
+[meta]
+   bind-address = "{{addr}}:8088"
+   heartbeat-timeout = "1s"`
+
+	confData, err := UpdateConfig(tmpl, newConf)
+	assert.NoError(t, err)
+
+	var confToml map[string]map[string]interface{}
+	_, err = toml.Decode(confData, &confToml)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(confToml["common"]))
+	assert.Equal(t, 6, len(confToml["meta"]))
+	assert.Equal(t, "{{HOST_IP}}:8088", confToml["meta"]["bind-address"])
+	assert.Equal(t, "1s", confToml["meta"]["heartbeat-timeout"])
+}
+
+func Test_UpdateConfig_Nested_OK(t *testing.T) {
+	tmpl := `
+[common] 
+meta-join = ["opengemini-meta-01.test.svc.cluster.local:8092", "opengemini-meta-02.test.svc.cluster.local:8092", "opengemini-meta-03.test.svc.cluster.local:8092"]
+cpu-num = 8  
+memory-size = "32G"
+
+[data]
+  store-ingest-addr = "{{HOST_IP}}:8400"
+  store-select-addr = "{{HOST_IP}}:8401"
+
+[data.ops-monitor]
+      store-http-addr = "{{HOST_IP}}:9999"`
+	newConf := `
+[data]
+  store-ingest-addr = "{{addr}}:8400"
+  store-select-addr = "{{addr}}:8401"
+
+[data.ops-monitor]
+      store-http-addr = "{{addr}}:9999"
+      auth-enabled = false`
+
+	confData, err := UpdateConfig(tmpl, newConf)
+	assert.NoError(t, err)
+
+	var confToml map[string]map[string]interface{}
+	_, err = toml.Decode(confData, &confToml)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(confToml["common"]))
+	assert.Equal(t, 3, len(confToml["data"]))
+	assert.Equal(t, "{{HOST_IP}}:8400", confToml["data"]["store-ingest-addr"])
+	assert.Equal(t, false, confToml["data"]["ops-monitor"].(map[string]interface{})["auth-enabled"])
+	assert.Equal(t, "{{HOST_IP}}:9999", confToml["data"]["ops-monitor"].(map[string]interface{})["store-http-addr"])
+}


### PR DESCRIPTION
close #16 


Support to update config file by specifying `opengemini.conf` config map key.

## tutorial:

> install crd 
> apply sample openGmeini cluster yaml
> run operator


```bash
kubectl -n opengemini delete cm custom-config

kubectl -n opengemini create configmap custom-config --from-file=opengemini.conf=./openGemini.conf
```

Waiting for openGemini cluster restart.


## `openGemini.conf` can reference: 

https://github.com/openGemini/openGemini/blob/bd8f5237e43227272c05a76432d7203093908786/config/openGemini.conf

