### PR TITLE
ci: fix goimports-reviser project name

### DIFF
--- a/api/v1/geminicluster_types.go
+++ b/api/v1/geminicluster_types.go
@@ -19,9 +19,10 @@ package v1
 import (
 	"fmt"
 
-	"github.com/openGemini/openGemini-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openGemini/openGemini-operator/pkg/utils"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/controllers/geminicluster_controller.go
+++ b/controllers/geminicluster_controller.go
@@ -23,12 +23,6 @@ import (
 
 	_ "github.com/influxdata/influxdb1-client"
 	influxClient "github.com/influxdata/influxdb1-client/v2"
-	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
-	"github.com/openGemini/openGemini-operator/pkg/configfile"
-	"github.com/openGemini/openGemini-operator/pkg/naming"
-	"github.com/openGemini/openGemini-operator/pkg/resources"
-	"github.com/openGemini/openGemini-operator/pkg/specs"
-	"github.com/openGemini/openGemini-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -39,6 +33,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
+	"github.com/openGemini/openGemini-operator/pkg/configfile"
+	"github.com/openGemini/openGemini-operator/pkg/naming"
+	"github.com/openGemini/openGemini-operator/pkg/resources"
+	"github.com/openGemini/openGemini-operator/pkg/specs"
+	"github.com/openGemini/openGemini-operator/pkg/utils"
 )
 
 const (

--- a/controllers/geminicluster_controller_test.go
+++ b/controllers/geminicluster_controller_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"testing"
 
-	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 )
 
 type MockK8sClient struct {

--- a/controllers/instance.go
+++ b/controllers/instance.go
@@ -3,15 +3,16 @@ package controllers
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 	"github.com/openGemini/openGemini-operator/pkg/opengemini/meta"
 	"github.com/openGemini/openGemini-operator/pkg/opengemini/sql"
 	"github.com/openGemini/openGemini-operator/pkg/opengemini/store"
 	"github.com/openGemini/openGemini-operator/pkg/utils"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +kubebuilder:rbac:groups="apps",resources="statefulsets",verbs={get,create,patch}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,13 +22,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	opengeminioperatorv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	opengeminioperatorv1 "github.com/openGemini/openGemini-operator/api/v1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/main.go
+++ b/main.go
@@ -20,8 +20,6 @@ import (
 	"flag"
 	"os"
 
-	opengeminioperatorv1 "github.com/openGemini/openGemini-operator/api/v1"
-	"github.com/openGemini/openGemini-operator/controllers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -31,6 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	opengeminioperatorv1 "github.com/openGemini/openGemini-operator/api/v1"
+	"github.com/openGemini/openGemini-operator/controllers"
 )
 
 var (

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/BurntSushi/toml"
+
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 )

--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"path"
 
-	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 )
 
 const (

--- a/pkg/naming/selectors.go
+++ b/pkg/naming/selectors.go
@@ -1,8 +1,9 @@
 package naming
 
 import (
-	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 )
 
 func ClusterInstances(cluster string) *metav1.LabelSelector {

--- a/pkg/opengemini/meta/meta.go
+++ b/pkg/opengemini/meta/meta.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 	"github.com/openGemini/openGemini-operator/pkg/specs"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func DataVolumeMount() corev1.VolumeMount {

--- a/pkg/opengemini/sql/sql.go
+++ b/pkg/opengemini/sql/sql.go
@@ -3,11 +3,12 @@ package sql
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 	"github.com/openGemini/openGemini-operator/pkg/specs"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func DataVolumeMount() corev1.VolumeMount {

--- a/pkg/opengemini/store/store.go
+++ b/pkg/opengemini/store/store.go
@@ -3,11 +3,12 @@ package store
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 	"github.com/openGemini/openGemini-operator/pkg/specs"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func DataVolumeMount() corev1.VolumeMount {

--- a/pkg/specs/configmap.go
+++ b/pkg/specs/configmap.go
@@ -1,8 +1,9 @@
 package specs
 
 import (
-	"github.com/openGemini/openGemini-operator/pkg/naming"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openGemini/openGemini-operator/pkg/naming"
 )
 
 func ConfigFileConfigmapProjection(configmapName string) *corev1.ConfigMapProjection {

--- a/pkg/specs/service.go
+++ b/pkg/specs/service.go
@@ -1,13 +1,14 @@
 package specs
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 	"github.com/openGemini/openGemini-operator/pkg/opengemini"
 	"github.com/openGemini/openGemini-operator/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func CreateClusterMaintainService(cluster *opengeminiv1.GeminiCluster) *corev1.Service {

--- a/scripts/ci/style_check.sh
+++ b/scripts/ci/style_check.sh
@@ -2,7 +2,7 @@
 
 echo "run style check for import pkg order"
 
-for file in $(find . -name '*.go'); do goimports-reviser -project-name none-pjn $file; done
+for file in $(find . -name '*.go'); do goimports-reviser -project-name github.com/openGemini/openGemini-operator $file; done
 
 GIT_STATUS=`git status | grep "Changes not staged for commit"`;
 if [ "$GIT_STATUS" = "" ]; then


### PR DESCRIPTION
fix ci error caused by goimports-reviser -project-name option