### PR TITLE
fix: allow custom cluster domain

### DIFF
--- a/pkg/naming/names.go
+++ b/pkg/naming/names.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
+	"github.com/openGemini/openGemini-operator/pkg/utils"
 )
 
 const (
@@ -50,9 +51,10 @@ func GenerateMetaInstance(cluster *opengeminiv1.GeminiCluster, index int) metav1
 
 func GenerateMetaHeadlessSvc(cluster *opengeminiv1.GeminiCluster, index int) string {
 	return fmt.Sprintf(
-		"%s.%s.svc.cluster.local",
+		"%s.%s.svc.%s",
 		GenerateMetaInstance(cluster, index).Name,
 		cluster.Namespace,
+		utils.GetClusterDomain(),
 	)
 }
 

--- a/pkg/opengemini/meta/meta.go
+++ b/pkg/opengemini/meta/meta.go
@@ -10,6 +10,7 @@ import (
 	opengeminiv1 "github.com/openGemini/openGemini-operator/api/v1"
 	"github.com/openGemini/openGemini-operator/pkg/naming"
 	"github.com/openGemini/openGemini-operator/pkg/specs"
+	"github.com/openGemini/openGemini-operator/pkg/utils"
 )
 
 func DataVolumeMount() corev1.VolumeMount {
@@ -89,7 +90,7 @@ func InstancePod(
 			},
 			{
 				Name:  "DOMAIN",
-				Value: fmt.Sprintf("%s.%s.svc.cluster.local", inInstanceName, inCluster.Namespace),
+				Value: fmt.Sprintf("%s.%s.svc.%s", inInstanceName, inCluster.Namespace, utils.GetClusterDomain()),
 			},
 		},
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"math/rand"
+	"os"
 	"strings"
 )
 
@@ -50,4 +51,16 @@ func GenPassword(length, numSymbols, numDigits, numUpperLetters int) string {
 		inRune[i], inRune[j] = inRune[j], inRune[i]
 	})
 	return string(inRune)
+}
+
+func GetClusterDomain() string {
+	return getEnvWithDefault("KUBERNETES_CLUSTER_DOMAIN", "cluster.local")
+}
+
+func getEnvWithDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return defaultValue
+	}
+	return value
 }

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetClusterDomain(t *testing.T) {
+	// Backup current environment variable
+	old := os.Getenv("KUBERNETES_CLUSTER_DOMAIN")
+
+	// Unset it for the first part of our test
+	os.Unsetenv("KUBERNETES_CLUSTER_DOMAIN")
+	domain := GetClusterDomain()
+	if domain != "cluster.local" {
+		t.Errorf("Expected default domain 'cluster.local', got '%s'", domain)
+	}
+
+	// Set it to a known value for the second part of our test
+	os.Setenv("KUBERNETES_CLUSTER_DOMAIN", "mycluster.local")
+	domain = GetClusterDomain()
+	if domain != "mycluster.local" {
+		t.Errorf("Expected domain 'mycluster.local', got '%s'", domain)
+	}
+
+	// Restore environment variable
+	os.Setenv("KUBERNETES_CLUSTER_DOMAIN", old)
+}


### PR DESCRIPTION
fix #26 
now we can provide custom domain name during helm install:
```
helm install operator ./chart --dry-run --debug --set kubernetesClusterDomain=mycluster.cc
```